### PR TITLE
fix: hero border curve

### DIFF
--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -90,6 +90,7 @@ const Hero: React.FC = () => {
 
           .Hero__page-curve {
             bottom: -1px;
+            width: 100%;
           }
 
           @media only screen and (max-width: 1080px) {


### PR DESCRIPTION
On chrome a bug existed where curve didn't span full screen width